### PR TITLE
Fixes #2 tmpfile can get deleted before curl executes on it.

### DIFF
--- a/netstorage/Service.php
+++ b/netstorage/Service.php
@@ -169,6 +169,7 @@ class Akamai_Netstorage_Service
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
 
+    $tmpfile = '';
 		if($method == 'PUT') {
 			$length = strlen($body);
 			if($length != 0){
@@ -176,7 +177,6 @@ class Akamai_Netstorage_Service
 				fwrite($tmpfile, $body);
 				fseek($tmpfile, 0);
 				curl_setopt($curl, CURLOPT_INFILE, $tmpfile);
-				fclose($tmpfile);
 			}
 			curl_setopt($curl, CURLOPT_UPLOAD, 1);
 			curl_setopt($curl, CURLOPT_INFILESIZE, strlen($body));
@@ -191,6 +191,11 @@ class Akamai_Netstorage_Service
 		$data = curl_exec($curl);
 		$this->_last_status_code = curl_getinfo($curl, CURLINFO_HTTP_CODE); 
 		curl_close($curl);
+
+    if($tmpfile) {
+		  fclose($tmpfile);
+    }
+
 		return $data;
 	}
 


### PR DESCRIPTION
Delays the closing of the tempfile until after the curl_exec.
